### PR TITLE
Lifecycle fix and default instance naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
+## Unreleased
+
+#### BUG FIXES:
+* Updated lifecycle hooks to prevent dependency cycles during destroy [GH-5]
 * Added proper lifecycle management to allow launch configuration updates [GH-2]
 * Removed `sg-` from ASG security group name [GH-1]
+
 ## 0.1.0 (Oct 26, 2015)
+
 * Initial Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+#### IMPROVEMENTS:
+* Added default Name tag to auto scaling groups [GH-6]
+
 #### BUG FIXES:
 * Updated lifecycle hooks to prevent dependency cycles during destroy [GH-5]
 * Added proper lifecycle management to allow launch configuration updates [GH-2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 #### IMPROVEMENTS:
+* Added ASG name to module outputs [GH-8]
 * Added default Name tag to auto scaling groups [GH-6]
 
 #### BUG FIXES:

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -9,8 +9,13 @@ provider "atlas" {}
 ## Sources inputs from VPC remote state
 resource "terraform_remote_state" "vpc" {
   backend = "atlas"
+
   config {
     name = "${var.organization}/${var.vpc_stack_name}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 
@@ -18,6 +23,11 @@ resource "terraform_remote_state" "vpc" {
 resource "aws_iam_role" "role" {
   name = "${var.stack_item_label}-${var.region}-example"
   path = "/"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -37,11 +47,20 @@ EOF
 resource "aws_iam_instance_profile" "instance_profile" {
   name = "${var.stack_item_label}-${var.region}-example"
   roles = ["${aws_iam_role.role.name}"]
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_iam_role_policy" "logs" {
     name = "monitoring"
     role = "${aws_iam_role.role.id}"
+
+    lifecycle {
+      create_before_destroy = true
+    }
+
     policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -66,6 +85,10 @@ resource "aws_security_group_rule" "ssh" {
   protocol = "tcp"
   cidr_blocks = ["${terraform_remote_state.vpc.output.lan_access_cidr}"]
   security_group_id = "${module.example.sg_id}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 ## Generates instance user data from a template
@@ -76,6 +99,10 @@ resource "template_file" "user_data" {
     hostname = "${var.stack_item_label}-example"
     domain = "example.org"
     region = "${var.region}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -11,3 +11,7 @@ output "lc_id" {
 output "asg_id" {
   value = "${module.example.asg_id}"
 }
+
+output "asg_name" {
+  value = "${module.example.asg_name}"
+}

--- a/examples/standard/main.tf
+++ b/examples/standard/main.tf
@@ -9,8 +9,13 @@ provider "atlas" {}
 ## Sources inputs from VPC remote state
 resource "terraform_remote_state" "vpc" {
   backend = "atlas"
+
   config {
     name = "${var.organization}/${var.vpc_stack_name}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 
@@ -18,6 +23,11 @@ resource "terraform_remote_state" "vpc" {
 resource "aws_iam_role" "role" {
   name = "${var.stack_item_label}-${var.region}-example"
   path = "/"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -37,11 +47,20 @@ EOF
 resource "aws_iam_instance_profile" "instance_profile" {
   name = "${var.stack_item_label}-${var.region}-example"
   roles = ["${aws_iam_role.role.name}"]
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_iam_role_policy" "logs" {
     name = "monitoring"
     role = "${aws_iam_role.role.id}"
+
+    lifecycle {
+      create_before_destroy = true
+    }
+
     policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -68,6 +87,10 @@ resource "aws_security_group" "sg_elb" {
     Name = "${var.stack_item_label}-example-elb"
     application = "${var.stack_item_fullname}"
     managed_by = "terraform"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 
   # Allow HTTP traffic
@@ -128,6 +151,10 @@ resource "aws_security_group_rule" "elb" {
   protocol = "tcp"
   source_security_group_id = "${aws_security_group.sg_elb.id}"
   security_group_id = "${module.example.sg_id}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 ## Generates instance user data from a template
@@ -138,6 +165,10 @@ resource "template_file" "user_data" {
     hostname = "${var.stack_item_label}-example"
     domain = "example.org"
     region = "${var.region}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 

--- a/examples/standard/outputs.tf
+++ b/examples/standard/outputs.tf
@@ -11,3 +11,7 @@ output "lc_id" {
 output "asg_id" {
   value = "${module.example.asg_id}"
 }
+
+output "asg_name" {
+  value = "${module.example.asg_name}"
+}

--- a/group/basic/main.tf
+++ b/group/basic/main.tf
@@ -56,7 +56,5 @@ resource "aws_autoscaling_group" "asg" {
     propagate_at_launch = true
   }
 
-  lifecycle {
-    create_before_destroy = true
   }
 }

--- a/group/basic/main.tf
+++ b/group/basic/main.tf
@@ -56,5 +56,9 @@ resource "aws_autoscaling_group" "asg" {
     propagate_at_launch = true
   }
 
+  tag {
+    key = "Name"
+    value = "${var.stack_item_label}"
+    propagate_at_launch = true
   }
 }

--- a/group/basic/main.tf
+++ b/group/basic/main.tf
@@ -2,7 +2,6 @@
 
 ## Creates security group
 resource "aws_security_group" "sg_asg" {
-  name = "${var.stack_item_label}-asg"
   description = "${var.stack_item_fullname} security group"
   vpc_id = "${var.vpc_id}"
 
@@ -17,6 +16,10 @@ resource "aws_security_group" "sg_asg" {
     from_port = 0
     to_port = 0
     protocol = "-1"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 

--- a/group/standard/main.tf
+++ b/group/standard/main.tf
@@ -58,5 +58,9 @@ resource "aws_autoscaling_group" "asg" {
     propagate_at_launch = true
   }
 
+  tag {
+    key = "Name"
+    value = "${var.stack_item_label}"
+    propagate_at_launch = true
   }
 }

--- a/group/standard/main.tf
+++ b/group/standard/main.tf
@@ -2,7 +2,6 @@
 
 ## Creates security group
 resource "aws_security_group" "sg_asg" {
-  name = "${var.stack_item_label}-asg"
   description = "${var.stack_item_fullname} security group"
   vpc_id = "${var.vpc_id}"
 
@@ -17,6 +16,10 @@ resource "aws_security_group" "sg_asg" {
     from_port = 0
     to_port = 0
     protocol = "-1"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 

--- a/group/standard/main.tf
+++ b/group/standard/main.tf
@@ -58,7 +58,5 @@ resource "aws_autoscaling_group" "asg" {
     propagate_at_launch = true
   }
 
-  lifecycle {
-    create_before_destroy = true
   }
 }


### PR DESCRIPTION
Updated lifecycle configuration of resources within the module as well as examples of consuming templates, which also require similar updates. I've also added a default name to the auto scaling group, which will be the same for all instances unless overwritten by some other mechanism.