### PR TITLE
Upgrade Terraform and file_template usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## Unreleased
+## 0.1.1 (Dec 1, 2015)
 
 #### IMPROVEMENTS:
+* Updated template_file usage for 0.6.7 to remove deprecation warnings [GH-9]
 * Added ASG name to module outputs [GH-8]
 * Added default Name tag to auto scaling groups [GH-6]
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Module stack supporting multiple deployment scenarios of an Auto Scaling Group t
 
 ## Requirements ##
 
-- Terraform 0.6.4 or newer
+- Terraform 0.6.7 or newer
 - AWS provider
 
 ## Basic Group Module ##

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   environment:
-    TF_VERSION: 0.6.6
-    TF_URL: https://dl.bintray.com/mitchellh/terraform/terraform_${TF_VERSION}_linux_amd64.zip
+    TF_VERSION: 0.6.7
+    TF_URL: https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip
 dependencies:
   pre:
     - "[[ -f \"${HOME}/bin/terraform\" ]] || (wget -O \"/tmp/tf.zip\" \"${TF_URL}\" && unzip -o -d \"${HOME}/bin\" \"/tmp/tf.zip\")"

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -93,7 +93,7 @@ resource "aws_security_group_rule" "ssh" {
 
 ## Generates instance user data from a template
 resource "template_file" "user_data" {
-  filename = "../templates/user_data.tpl"
+  template = "${file("../templates/user_data.tpl")}"
 
   vars {
     hostname = "${var.stack_item_label}-example"

--- a/examples/standard/main.tf
+++ b/examples/standard/main.tf
@@ -159,7 +159,7 @@ resource "aws_security_group_rule" "elb" {
 
 ## Generates instance user data from a template
 resource "template_file" "user_data" {
-  filename = "../templates/user_data.tpl"
+  template = "${file("../templates/user_data.tpl")}"
 
   vars {
     hostname = "${var.stack_item_label}-example"


### PR DESCRIPTION
Updated usage of `file_template` resources to replace the deprecated `filename` parameter with the `template` parameter. Updated documentation and build for Terraform 0.6.7.