### PR TITLE
treat_missing_data attribute support

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ module "absolute_policy" {
   period              = 120
   scaling_adjustment  = 4
   threshold           = 10
+  treat_missing_data  = "bad"
 }
 ```
 
@@ -348,6 +349,7 @@ module "percentage_policy" {
   period                   = 120
   scaling_adjustment       = 4
   threshold                = 10
+  treat_missing_data       = "bad"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ module "absolute_policy" {
   period              = 120
   scaling_adjustment  = 4
   threshold           = 10
-  treat_missing_data  = "bad"
+  treat_missing_data  = "breaching"
 }
 ```
 
@@ -349,7 +349,7 @@ module "percentage_policy" {
   period                   = 120
   scaling_adjustment       = 4
   threshold                = 10
-  treat_missing_data       = "bad"
+  treat_missing_data       = "breaching"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,12 @@ applied.
 associated metric. Valid values are **SampleCount**, **Average**, **Sum**,
 **Minimum** and **Maximum**.
 * `threshold` - The value against which the specified statistic is compared.
+* [`treat_missing_data`](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-missing-data) - (Default: **missing**) How alarms handle missing
+data points. Valid values are:
+  * **missing** - Missing (the alarm looks back farther in time to find additional data points)
+  * **ignore** - Good ("Not Breaching," treated as a data point that is within the threshold)
+  * **breaching** - Bad ("Breaching," treated as a data point that is breaching the threshold)
+  * **notBreaching** - Ignored (the current alarm state is maintained)
 
 ### Usage
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
 require 'rake'
 require 'covalence/environment_tasks'
-require 'covalence/packer_tasks'
 require 'covalence/spec_tasks'

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -216,4 +216,5 @@ module "scale_up_policy" {
   period              = 120
   scaling_adjustment  = 30
   threshold           = 10
+  treat_missing_data  = "breaching"
 }

--- a/policy/main.tf
+++ b/policy/main.tf
@@ -46,4 +46,5 @@ resource "aws_cloudwatch_metric_alarm" "monitor_asg" {
   period             = "${var.period}"
   statistic          = "${lookup(var.valid_statistics, var.statistic)}"
   threshold          = "${var.threshold}"
+  treat_missing_data = "${var.treat_missing_data}"
 }

--- a/policy/main.tf
+++ b/policy/main.tf
@@ -46,5 +46,5 @@ resource "aws_cloudwatch_metric_alarm" "monitor_asg" {
   period             = "${var.period}"
   statistic          = "${lookup(var.valid_statistics, var.statistic)}"
   threshold          = "${var.threshold}"
-  treat_missing_data = "${var.treat_missing_data}"
+  treat_missing_data = "${lookup(var.valid_missing_data, var.treat_missing_data)}"
 }

--- a/policy/variables.tf
+++ b/policy/variables.tf
@@ -78,6 +78,11 @@ variable "threshold" {
   description = "The value against which the specified statistic is compared."
 }
 
+variable "treat_missing_data" {
+  type        = "string"
+  description = "See http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-missing-data"
+}
+
 variable "valid_statistics" {
   type = "map"
 

--- a/policy/variables.tf
+++ b/policy/variables.tf
@@ -80,7 +80,19 @@ variable "threshold" {
 
 variable "treat_missing_data" {
   type        = "string"
-  description = "See http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-missing-data"
+  description = "You can specfy how alarms handle missing data points. Valid values are 'missing': the alarm looks back farther in time to find additional data points, 'notBreaching': treated as a data point that is within the threshold, 'breaching': treated as a data point that is breaching the threshold, 'ignore': the current alarm state is maintained."
+  default     = "missing"
+}
+
+variable "valid_missing_data" {
+  type = "map"
+
+  default = {
+    missing      = "missing"
+    ignore       = "ignore"
+    breaching    = "breaching"
+    notBreaching = "notBreaching"
+  }
 }
 
 variable "valid_statistics" {


### PR DESCRIPTION
[Original PR](https://github.com/unifio/terraform-aws-asg/pull/23)
- Created new branch and made some modifications to [original PR](https://github.com/unifio/terraform-aws-asg/pull/23). 
### Clean up treat_missing_data pr
- Added map to avoid typos not triggering an error.
- Added default to missing since that is the default in terraform resource so should be in parity with that.
- Added documentation from AWS and link to documentation in readme explaining each permitted value and the default that will be used.
### Added support for latest unifio/ci
- Removed packer requirement in Rakefile
- Added treat_missing_data variable to the ci environment stack for testing.