### PR TITLE
Allow whether to configure name tag in instances in ASG

### DIFF
--- a/group/asg/main.tf
+++ b/group/asg/main.tf
@@ -32,7 +32,7 @@ resource "aws_autoscaling_group" "asg" {
   tag {
     key                 = "Name"
     value               = "${length(var.asg_name_override) > 0 ? var.asg_name_override : var.stack_item_label}"
-    propagate_at_launch = true
+    propagate_at_launch = "${var.propagate_name_at_launch}"
   }
 
   tag {
@@ -76,7 +76,7 @@ resource "aws_autoscaling_group" "asg_elb" {
   tag {
     key                 = "Name"
     value               = "${length(var.asg_name_override) > 0 ? var.asg_name_override : var.stack_item_label}"
-    propagate_at_launch = true
+    propagate_at_launch = "${var.propagate_name_at_launch}"
   }
 
   tag {

--- a/group/asg/variables.tf
+++ b/group/asg/variables.tf
@@ -14,6 +14,11 @@ variable "asg_name_override" {
   type = "string"
 }
 
+variable "propagate_name_at_launch" {
+  type    = "string"
+  default = "true"
+}
+
 ## VPC parameters
 variable "subnets" {
   type = "list"

--- a/group/main.tf
+++ b/group/main.tf
@@ -95,9 +95,10 @@ module "asg" {
   source = "asg"
 
   ### Resource tags
-  stack_item_label    = "${var.stack_item_label}"
-  stack_item_fullname = "${var.stack_item_fullname}"
-  asg_name_override   = "${var.asg_name_override}"
+  stack_item_label         = "${var.stack_item_label}"
+  stack_item_fullname      = "${var.stack_item_fullname}"
+  asg_name_override        = "${var.asg_name_override}"
+  propagate_name_at_launch = "${var.propagate_name_at_launch}"
 
   ### VPC parameters
   subnets = ["${var.subnets}"]

--- a/group/variables.tf
+++ b/group/variables.tf
@@ -23,6 +23,12 @@ variable "lc_sg_name_prefix_override" {
   default     = ""
 }
 
+variable "propagate_name_at_launch" {
+  type        = "string"
+  description = "A string to override the ASG name"
+  default     = "false"
+}
+
 ## VPC parameters
 variable "subnets" {
   type        = "list"


### PR DESCRIPTION
ASG configures the name tag on instances it launches.  Make this configurable as we want to tag them separately.  Other tags are useful to keep turned on.