### PR TITLE
Ability to extend asg tags at both group and group/asg levels

### DIFF
--- a/group/asg/main.tf
+++ b/group/asg/main.tf
@@ -1,6 +1,26 @@
 # AWS Auto Scaling Group
 
 ## Creates auto scaling group
+locals {
+  default_asg_tags = [
+    {
+      key                 = "application"
+      value               = "${var.stack_item_fullname}"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "Name"
+      value               = "${length(var.asg_name_override) > 0 ? var.asg_name_override : var.stack_item_label}"
+      propagate_at_launch = "${var.propagate_name_at_launch}"
+    },
+    {
+      key                 = "managed_by"
+      value               = "terraform"
+      propagate_at_launch = true
+    },
+  ]
+}
+
 resource "aws_autoscaling_group" "asg" {
   count = "${length(var.min_elb_capacity) > 0 || length(var.wait_for_elb_capacity) > 0 ? 0 : 1}"
 
@@ -23,23 +43,7 @@ resource "aws_autoscaling_group" "asg" {
   vpc_zone_identifier       = ["${compact(var.subnets)}"]
   wait_for_capacity_timeout = "${length(var.wait_for_capacity_timeout) > 0 ? var.wait_for_capacity_timeout : "10m"}"
 
-  tag {
-    key                 = "application"
-    value               = "${var.stack_item_fullname}"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key                 = "Name"
-    value               = "${length(var.asg_name_override) > 0 ? var.asg_name_override : var.stack_item_label}"
-    propagate_at_launch = "${var.propagate_name_at_launch}"
-  }
-
-  tag {
-    key                 = "managed_by"
-    value               = "terraform"
-    propagate_at_launch = true
-  }
+  tags = "${concat(local.default_asg_tags, var.additional_asg_tags)}"
 }
 
 resource "aws_autoscaling_group" "asg_elb" {
@@ -67,21 +71,5 @@ resource "aws_autoscaling_group" "asg_elb" {
   wait_for_capacity_timeout = "${length(var.wait_for_capacity_timeout) > 0 ? var.wait_for_capacity_timeout : "10m"}"
   wait_for_elb_capacity     = "${length(var.wait_for_elb_capacity) > 0 ? var.wait_for_elb_capacity : "0"}"
 
-  tag {
-    key                 = "application"
-    value               = "${var.stack_item_fullname}"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key                 = "Name"
-    value               = "${length(var.asg_name_override) > 0 ? var.asg_name_override : var.stack_item_label}"
-    propagate_at_launch = "${var.propagate_name_at_launch}"
-  }
-
-  tag {
-    key                 = "managed_by"
-    value               = "terraform"
-    propagate_at_launch = true
-  }
+  tags = "${concat(local.default_asg_tags, var.additional_asg_tags)}"
 }

--- a/group/asg/variables.tf
+++ b/group/asg/variables.tf
@@ -9,6 +9,11 @@ variable "stack_item_label" {
   type = "string"
 }
 
+variable "additional_asg_tags" {
+  type    = "list"
+  default = []
+}
+
 ## Allow override of resource naming
 variable "asg_name_override" {
   type = "string"

--- a/group/main.tf
+++ b/group/main.tf
@@ -119,6 +119,7 @@ module "asg" {
   suspended_processes       = ["${var.suspended_processes}"]
   termination_policies      = ["${var.termination_policies}"]
   wait_for_capacity_timeout = "${var.wait_for_capacity_timeout}"
+  additional_asg_tags       = "${var.additional_asg_tags}"
 
   ### ELB parameters
   load_balancers        = ["${var.load_balancers}"]

--- a/group/variables.tf
+++ b/group/variables.tf
@@ -201,6 +201,12 @@ variable "user_data" {
 }
 
 ## ASG parameters
+variable "additional_asg_tags" {
+  type        = "list"
+  description = "Additional tags to apply at the ASG level, if any"
+  default     = []
+}
+
 variable "default_cooldown" {
   type        = "string"
   description = "The amount of time, in seconds, after a scaling activity completes before another scaling activity can start."


### PR DESCRIPTION
This allows the ability to extend the default set of tags attached to
the asg when referencing the asg or group module.